### PR TITLE
Added styleguidist with styled-components

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -7,7 +7,9 @@
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject",
-    "coverage": "npm test -- --coverage"
+    "coverage": "npm test -- --coverage",
+    "styleguide": "styleguidist server",
+    "styleguide:build": "styleguidist build"
   },
   "proxy": {
     "/api/*": {
@@ -16,6 +18,7 @@
   },
   "dependencies": {
     "axios": "^0.16.2",
+    "bemto-components": "^1.2.0",
     "lodash": "^4.17.4",
     "materialize-css": "^0.100.2",
     "react": "^15.6.1",
@@ -25,7 +28,13 @@
     "react-router-dom": "^4.2.2",
     "react-scripts": "1.0.10",
     "redux": "^3.7.2",
+    "redux-promise": "^0.5.3",
     "redux-thunk": "^2.2.0",
+    "styled-components": "^2.2.3",
     "validator": "^9.0.0"
+  },
+  "devDependencies": {
+    "react-docgen-annotation-resolver": "^1.0.0",
+    "react-styleguidist": "^6.0.32"
   }
 }

--- a/client/src/components/ui/Button/Readme.md
+++ b/client/src/components/ui/Button/Readme.md
@@ -1,0 +1,27 @@
+`<Button>` component for our buttons.
+
+### Examples
+
+Simple button:
+
+    <Button>Click me</Button>
+
+Simple button, but as a link with href:
+
+    <Button href="#x">Click me</Button>
+
+A button with a onClick event that shows a browser alert:
+
+    <Button onClick={() => alert('You have clicked me!')}>Click me</Button>
+
+A bigger button, with a `_big` modifier.
+
+    <Button _big>Click me</Button>
+
+A button with rounded corners, with a `_rounded` modifier.
+
+    <Button _rounded>Click me</Button>
+
+A button with all the modifiers.
+
+    <Button _big _rounded>Click me</Button>

--- a/client/src/components/ui/Button/index.js
+++ b/client/src/components/ui/Button/index.js
@@ -1,0 +1,31 @@
+import bemto from 'bemto-components';
+import styled from 'styled-components';
+
+const Button = styled(bemto('button'))`
+  cursor: pointer;
+
+  border: 1px solid;
+  padding: 10px;
+
+  text-decoration: none;
+
+  color: #000;
+  background: #FFF;
+
+  &:hover {
+    color: #FFF;
+    background: #000;
+  }
+
+  &_big {
+    padding: 15px;
+    font-size: 2em;
+  }
+
+  &_rounded {
+    border-radius: 9em;
+  }
+`;
+
+/** @component */
+export default Button;

--- a/client/src/components/ui/Page/Readme.md
+++ b/client/src/components/ui/Page/Readme.md
@@ -1,0 +1,35 @@
+`<Page>` Component for the top-level layout.
+
+### `<Page>`
+
+Creates the wrapper for the Page:
+
+    <Page>Whatever</Page>
+
+#### `<Page.Header>` element
+
+Creates a Header element of our Page:
+
+    <Page.Header>Hello, world!</Page.Header>
+
+#### `<Page.Content>` element
+
+Creates a Content element of our Page:
+
+    <Page.Content>Hello, world!</Page.Content>
+
+
+### Complex example:
+
+We can put there all the different compositions of elements on Pages like this:
+
+    <Page>
+      <Page.Header>
+        <Button href="#Foo">Foo</Button>
+        <Button href="#Bar">Bar</Button>
+        <Button href="#Baz">Baz</Button>
+      </Page.Header>
+      <Page.Content>
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit. Non, repellendus. Praesentium facilis commodi ut voluptatum nulla, laudantium quidem cupiditate quia pariatur impedit est omnis illum, optio fuga voluptatibus velit odio?
+      </Page.Content>
+    </Page>

--- a/client/src/components/ui/Page/index.js
+++ b/client/src/components/ui/Page/index.js
@@ -1,0 +1,20 @@
+import bemto from 'bemto-components';
+import styled from 'styled-components';
+
+const Page = styled(bemto())`
+  background: #BBB;
+`;
+
+Page.Header = styled(bemto())`
+  padding: 20px;
+  color: #FFF;
+  background: #000;
+`;
+
+Page.Content = styled(bemto())`
+  padding: 20px;
+  border: 1px solid;
+`;
+
+/** @component */
+export default Page;

--- a/client/styleguide.config.js
+++ b/client/styleguide.config.js
@@ -1,0 +1,27 @@
+// Only until https://github.com/styled-components/styled-components/issues/945#issuecomment-340166853 would be merged
+
+const defaultResolver = require("react-docgen").resolver.findAllExportedComponentDefinitions;
+const annotationResolver = require("react-docgen-annotation-resolver").default;
+
+module.exports = {
+  title: 'Dybr UI',
+  sections: [
+    {
+      name: 'Introduction',
+      content: './styleguide/Readme.md'
+    },
+    {
+      name: 'UI Components',
+      components: './src/components/**/index.js'
+    }
+  ],
+
+  styleguideDir: './styleguide/out',
+
+  resolver: (ast, recast) => {
+    const annotatedComponents = annotationResolver(ast, recast);
+    const defaultComponents = defaultResolver(ast, recast);
+
+    return annotatedComponents.concat(defaultComponents);
+  }
+};

--- a/client/styleguide/Readme.md
+++ b/client/styleguide/Readme.md
@@ -1,0 +1,73 @@
+## Running Styleguide
+
+This styleguide is using [react-styleguidist](https://github.com/styleguidist/react-styleguidist). After cloning the project and `npm i` inside of it, you could run the dev server with the interactive styleguide by running this command:
+
+``` sh static
+npm run styleguide
+```
+
+And then opening its local address in your browser (by fefault — http://localhost:6060/).
+
+## Which components are shown there?
+
+Only the components that have a specific file structure would be shown in this styleguide: the component should have its own directory with its code placed in its `index.js`. Then, there should be `Readme.md` inside this component's folder with all the corresponding docs. You could place any includes, local tests etc. right along this component, all of this makes it really easy to understand what goes into any specific component.
+
+## Using styled-components
+
+All the components for the UI should be done using styled-components. The example `index.js` for a component could look like this:
+
+``` js static
+import bemto from 'bemto-components';
+import styled from 'styled-components';
+
+const Block = styled(bemto())`
+  border: 1px solid;
+
+  &_big {
+    font-size: 2em;
+  }
+`;
+
+Block.Element = styled(bemto())`
+  padding: 10px;
+  background: blue;
+
+  ${Block}:hover > & {
+    background: lime;
+  }
+
+  ${Block}_big > & {
+    padding: 25px;
+  }
+`;
+
+/** @component */
+export default Block;
+```
+
+After doing so and importing later this component, you could use it like this in JSX:
+
+``` xml static
+<Block _big className='additional-classname'>
+  <Block.Element>Foo</Block.Element>
+  <Block.Element title='Bar’s title'>Bar</Block.Element>
+</Block>
+```
+
+A few things to note:
+
+1. You could see how we can add BEM-like “Elements” for our components: just by adding them as properties to our component. This would allow us to use those elements whenever we export our components, so they essentially become a part of components' API.
+
+2. I've used there also a thing used `bemto-components`: you can see it used instead of a tag for styled-components: `.styled(bemto())` — what it does is it enables us to use BEM-like modifiers for our components! That means that we can just write `<Block _big>` and it would generate a modifier for our component based on its generated className, so we could then just use `&_big` at component's CSS and get the expected result.
+
+    And another thing bemto-components allows us to do: create polymorphic components that could be rendered as different HTML tags based on which props/attributes they were called with. For example, we can have buttons that are `<button>` by default, but as soon as we pass `href` to them, they could become `<a>`. That can be really useful in a lot of cases.
+
+2. You can use the `${Block}` interpolation to use any other component (or parent blocks) as part of the CSS selectors. Styled-components are smart enough to get the generated className and apply it there.
+
+3. Styled-components would pass all the props/attributes to the generated HTML of components, so its really easy to add any extra classNames or attributes like `title` to your components when you call them.
+
+4. When you export your component you need to declare that you export it as component: `/** @component */`, this is needed so Styleguidist would understand that it is a component that could be displayed at the styleguide.
+
+- - -
+
+*Disclaimer:* This is just an example of Styleguidist, components below are there to just demonstrate how they're used. We can start adding our proper components there when we'd have then, or convert existing ones to the ones that we could display at styleguide. This would make it so we'd need to separate the UI part of the component from its logic, and that is a really nice thing in styleguide-driven development! Enjoy!


### PR DESCRIPTION
That's basically boilerplate for starting creating all the HTML & CSS for our UI and pages.

Here is how it would look like: https://aspieipsa.github.io/DiaryCommunity/

When running locally (with `npm run styleguide`) there would be a dev server with the above stuff, hot reloading etc., all of this makes it really easy to develop new components and/or edit old ones.

Note that there is a `CODE` button under all the examples, which allows you to play right there with all the available components as in an interactive playground (really nice for testing different cases and combinations of components).